### PR TITLE
Fix uint4 ctor | operator != and == for uint | Missing scalar int4/uint4 cmp 

### DIFF
--- a/include/hlsl++_vector_int.h
+++ b/include/hlsl++_vector_int.h
@@ -569,6 +569,16 @@ namespace hlslpp
 	hlslpp_inline int3& operator *= (int3& i1, const int3& i2) { i1 = i1 * i2; return i1; }
 	hlslpp_inline int4& operator *= (int4& i1, const int4& i2) { i1 = i1 * i2; return i1; }
 
+    hlslpp_inline bool any(const int1& i) { return 0 != i.x; }
+    hlslpp_inline bool any(const int2& i) { return 0 != i.x || 0 != i.y; }
+    hlslpp_inline bool any(const int3& i) { return 0 != i.x || 0 != i.y || 0 != i.z; }
+    hlslpp_inline bool any(const int4& i) { return 0 != i.x || 0 != i.y || 0 != i.z || 0 != i.w; }
+
+    hlslpp_inline bool all(const int1& i) { return 0 != i.x; }
+    hlslpp_inline bool all(const int2& i) { return 0 != i.x && 0 != i.y; }
+    hlslpp_inline bool all(const int3& i) { return 0 != i.x && 0 != i.y && 0 != i.z; }
+    hlslpp_inline bool all(const int4& i) { return 0 != i.x && 0 != i.y && 0 != i.z && 0 != i.w; }
+
 	hlslpp_inline int1 operator == (const int1& i1, const int1& i2) { return int1(_hlslpp_cmpeq1_epi32(i1.vec, i2.vec)); }
 	hlslpp_inline int2 operator == (const int2& i1, const int2& i2) { return int2(_hlslpp_cmpeq1_epi32(i1.vec, i2.vec)); }
 	hlslpp_inline int3 operator == (const int3& i1, const int3& i2) { return int3(_hlslpp_cmpeq1_epi32(i1.vec, i2.vec)); }

--- a/include/hlsl++_vector_int.h
+++ b/include/hlsl++_vector_int.h
@@ -569,16 +569,6 @@ namespace hlslpp
 	hlslpp_inline int3& operator *= (int3& i1, const int3& i2) { i1 = i1 * i2; return i1; }
 	hlslpp_inline int4& operator *= (int4& i1, const int4& i2) { i1 = i1 * i2; return i1; }
 
-    hlslpp_inline bool any(const int1& i) { return 0 != i.x; }
-    hlslpp_inline bool any(const int2& i) { return 0 != i.x || 0 != i.y; }
-    hlslpp_inline bool any(const int3& i) { return 0 != i.x || 0 != i.y || 0 != i.z; }
-    hlslpp_inline bool any(const int4& i) { return 0 != i.x || 0 != i.y || 0 != i.z || 0 != i.w; }
-
-    hlslpp_inline bool all(const int1& i) { return 0 != i.x; }
-    hlslpp_inline bool all(const int2& i) { return 0 != i.x && 0 != i.y; }
-    hlslpp_inline bool all(const int3& i) { return 0 != i.x && 0 != i.y && 0 != i.z; }
-    hlslpp_inline bool all(const int4& i) { return 0 != i.x && 0 != i.y && 0 != i.z && 0 != i.w; }
-
 	hlslpp_inline int1 operator == (const int1& i1, const int1& i2) { return int1(_hlslpp_cmpeq1_epi32(i1.vec, i2.vec)); }
 	hlslpp_inline int2 operator == (const int2& i1, const int2& i2) { return int2(_hlslpp_cmpeq1_epi32(i1.vec, i2.vec)); }
 	hlslpp_inline int3 operator == (const int3& i1, const int3& i2) { return int3(_hlslpp_cmpeq1_epi32(i1.vec, i2.vec)); }

--- a/include/hlsl++_vector_uint.h
+++ b/include/hlsl++_vector_uint.h
@@ -574,16 +574,6 @@ namespace hlslpp
 	hlslpp_inline uint3& operator *= (uint3& i1, const uint3& i2) { i1 = i1 * i2; return i1; }
 	hlslpp_inline uint4& operator *= (uint4& i1, const uint4& i2) { i1 = i1 * i2; return i1; }
 
-    hlslpp_inline bool any(const uint1& i) { return 0 != i.x; }
-    hlslpp_inline bool any(const uint2& i) { return 0 != i.x || 0 != i.y; }
-    hlslpp_inline bool any(const uint3& i) { return 0 != i.x || 0 != i.y || 0 != i.z; }
-    hlslpp_inline bool any(const uint4& i) { return 0 != i.x || 0 != i.y || 0 != i.z || 0 != i.w; }
-
-    hlslpp_inline bool all(const uint1& i) { return 0 != i.x; }
-    hlslpp_inline bool all(const uint2& i) { return 0 != i.x && 0 != i.y; }
-    hlslpp_inline bool all(const uint3& i) { return 0 != i.x && 0 != i.y && 0 != i.z; }
-    hlslpp_inline bool all(const uint4& i) { return 0 != i.x && 0 != i.y && 0 != i.z && 0 != i.w; }
-
 	hlslpp_inline uint1 operator == (const uint1& i1, const uint1& i2) { return uint1(_hlslpp_cmpeq1_epu32(i1.vec, i2.vec)); }
 	hlslpp_inline uint2 operator == (const uint2& i1, const uint2& i2) { return uint2(_hlslpp_cmpeq1_epu32(i1.vec, i2.vec)); }
 	hlslpp_inline uint3 operator == (const uint3& i1, const uint3& i2) { return uint3(_hlslpp_cmpeq1_epu32(i1.vec, i2.vec)); }

--- a/include/hlsl++_vector_uint.h
+++ b/include/hlsl++_vector_uint.h
@@ -574,15 +574,26 @@ namespace hlslpp
 	hlslpp_inline uint3& operator *= (uint3& i1, const uint3& i2) { i1 = i1 * i2; return i1; }
 	hlslpp_inline uint4& operator *= (uint4& i1, const uint4& i2) { i1 = i1 * i2; return i1; }
 
-	//hlslpp_inline uint1 operator == (const uint1& i1, const uint1& i2) { return uint1(_hlslpp_cmpeq1_epu32(i1.vec, i2.vec)); }
-	//hlslpp_inline uint2 operator == (const uint2& i1, const uint2& i2) { return uint2(_hlslpp_cmpeq1_epu32(i1.vec, i2.vec)); }
-	//hlslpp_inline uint3 operator == (const uint3& i1, const uint3& i2) { return uint3(_hlslpp_cmpeq1_epu32(i1.vec, i2.vec)); }
-	//hlslpp_inline uint4 operator == (const uint4& i1, const uint4& i2) { return uint4(_hlslpp_cmpeq1_epu32(i1.vec, i2.vec)); }
-	//
-	//hlslpp_inline uint1 operator != (const uint1& i1, const uint1& i2) { return uint1(_hlslpp_cmpneq1_epu32(i1.vec, i2.vec)); }
-	//hlslpp_inline uint2 operator != (const uint2& i1, const uint2& i2) { return uint2(_hlslpp_cmpneq1_epu32(i1.vec, i2.vec)); }
-	//hlslpp_inline uint3 operator != (const uint3& i1, const uint3& i2) { return uint3(_hlslpp_cmpneq1_epu32(i1.vec, i2.vec)); }
-	//hlslpp_inline uint4 operator != (const uint4& i1, const uint4& i2) { return uint4(_hlslpp_cmpneq1_epu32(i1.vec, i2.vec)); }
+    hlslpp_inline bool any(const uint1& i) { return 0 != i.x; }
+    hlslpp_inline bool any(const uint2& i) { return 0 != i.x || 0 != i.y; }
+    hlslpp_inline bool any(const uint3& i) { return 0 != i.x || 0 != i.y || 0 != i.z; }
+    hlslpp_inline bool any(const uint4& i) { return 0 != i.x || 0 != i.y || 0 != i.z || 0 != i.w; }
+
+    hlslpp_inline bool all(const uint1& i) { return 0 != i.x; }
+    hlslpp_inline bool all(const uint2& i) { return 0 != i.x && 0 != i.y; }
+    hlslpp_inline bool all(const uint3& i) { return 0 != i.x && 0 != i.y && 0 != i.z; }
+    hlslpp_inline bool all(const uint4& i) { return 0 != i.x && 0 != i.y && 0 != i.z && 0 != i.w; }
+
+	hlslpp_inline uint1 operator == (const uint1& i1, const uint1& i2) { return uint1(_hlslpp_cmpeq1_epu32(i1.vec, i2.vec)); }
+	hlslpp_inline uint2 operator == (const uint2& i1, const uint2& i2) { return uint2(_hlslpp_cmpeq1_epu32(i1.vec, i2.vec)); }
+	hlslpp_inline uint3 operator == (const uint3& i1, const uint3& i2) { return uint3(_hlslpp_cmpeq1_epu32(i1.vec, i2.vec)); }
+	hlslpp_inline uint4 operator == (const uint4& i1, const uint4& i2) { return uint4(_hlslpp_cmpeq1_epu32(i1.vec, i2.vec)); }
+	
+	hlslpp_inline uint1 operator != (const uint1& i1, const uint1& i2) { return uint1(_hlslpp_cmpneq1_epu32(i1.vec, i2.vec)); } 
+	hlslpp_inline uint2 operator != (const uint2& i1, const uint2& i2) { return uint2(_hlslpp_cmpneq1_epu32(i1.vec, i2.vec)); }
+	hlslpp_inline uint3 operator != (const uint3& i1, const uint3& i2) { return uint3(_hlslpp_cmpneq1_epu32(i1.vec, i2.vec)); }
+	hlslpp_inline uint4 operator != (const uint4& i1, const uint4& i2) { return uint4(_hlslpp_cmpneq1_epu32(i1.vec, i2.vec)); }
+
 	//
 	//hlslpp_inline uint1 operator > (const uint1& i1, const uint1& i2) { return uint1(_hlslpp_cmpgt1_epu32(i1.vec, i2.vec)); }
 	//hlslpp_inline uint2 operator > (const uint2& i1, const uint2& i2) { return uint2(_hlslpp_cmpgt1_epu32(i1.vec, i2.vec)); }

--- a/include/platforms/hlsl++_scalar.h
+++ b/include/platforms/hlsl++_scalar.h
@@ -457,33 +457,33 @@ namespace hlslpp
     hlslpp_inline vector_int4 _hlslpp_cmpeq_epi32(const vector_int4& x, const vector_int4& y)
 	{
 		return vector_int4(x.x == y.x ? 1 : 0,
-                            x.y == y.y ? 1 : 0, 
-                            x.z == y.z ? 1 : 0, 
-                            x.w == y.w ? 1 : 0);
+                           x.y == y.y ? 1 : 0, 
+                           x.z == y.z ? 1 : 0, 
+                           x.w == y.w ? 1 : 0);
 	}
 
 	hlslpp_inline vector_int4 _hlslpp_cmpneq_epi32(const vector_int4& x, const vector_int4& y)
 	{
 		return vector_int4(x.x != y.x ? 1 : 0,
-                            x.y != y.y ? 1 : 0, 
-                            x.z != y.z ? 1 : 0, 
-                            x.w != y.w ? 1 : 0);
+                           x.y != y.y ? 1 : 0, 
+                           x.z != y.z ? 1 : 0, 
+                           x.w != y.w ? 1 : 0);
 	}
 
 	hlslpp_inline vector_int4 _hlslpp_cmpgt_epi32(const vector_int4& x, const vector_int4& y)
 	{
 		return vector_int4(x.x > y.x ? 1 : 0,
-                            x.y > y.y ? 1 : 0, 
-                            x.z > y.z ? 1 : 0, 
-                            x.w > y.w ? 1 : 0);
+                           x.y > y.y ? 1 : 0, 
+                           x.z > y.z ? 1 : 0, 
+                           x.w > y.w ? 1 : 0);
 	}
 
 	hlslpp_inline vector_int4 _hlslpp_cmpge_epi32(const vector_int4& x, const vector_int4& y)
 	{
 		return vector_int4(x.x >= y.x ? 1 : 0,
-                            x.y >= y.y ? 1 : 0, 
-                            x.z >= y.z ? 1 : 0, 
-                            x.w >= y.w ? 1 : 0);
+                           x.y >= y.y ? 1 : 0, 
+                           x.z >= y.z ? 1 : 0, 
+                           x.w >= y.w ? 1 : 0);
 	}
 
 	hlslpp_inline vector_int4 _hlslpp_cmplt_epi32(const vector_int4& x, const vector_int4& y)

--- a/include/platforms/hlsl++_scalar.h
+++ b/include/platforms/hlsl++_scalar.h
@@ -454,14 +454,53 @@ namespace hlslpp
 
 	hlslpp_inline vector_int4 _hlslpp_abs_epi32(const vector_int4& v) { return vector_int4(std::abs(v.x), std::abs(v.y), std::abs(v.z), std::abs(v.w)); }
 
-	hlslpp_inline vector_int4 _hlslpp_cmpeq_epi32(const vector_int4& x, const vector_int4& y) { return vector_int4(0, 0, 0, 0); }
-	hlslpp_inline vector_int4 _hlslpp_cmpneq_epi32(const vector_int4& x, const vector_int4& y) { return vector_int4(0, 0, 0, 0); }
+    hlslpp_inline vector_int4 _hlslpp_cmpeq_epi32(const vector_int4& x, const vector_int4& y)
+	{
+		return vector_int4(x.x == y.x ? 1 : 0,
+                            x.y == y.y ? 1 : 0, 
+                            x.z == y.z ? 1 : 0, 
+                            x.w == y.w ? 1 : 0);
+	}
 
-	hlslpp_inline vector_int4 _hlslpp_cmpgt_epi32(const vector_int4& x, const vector_int4& y) { return vector_int4(0, 0, 0, 0); }
-	hlslpp_inline vector_int4 _hlslpp_cmpge_epi32(const vector_int4& x, const vector_int4& y) { return vector_int4(0, 0, 0, 0); }
+	hlslpp_inline vector_int4 _hlslpp_cmpneq_epi32(const vector_int4& x, const vector_int4& y)
+	{
+		return vector_int4(x.x != y.x ? 1 : 0,
+                            x.y != y.y ? 1 : 0, 
+                            x.z != y.z ? 1 : 0, 
+                            x.w != y.w ? 1 : 0);
+	}
 
-	hlslpp_inline vector_int4 _hlslpp_cmplt_epi32(const vector_int4& x, const vector_int4& y) { return vector_int4(0, 0, 0, 0); }
-	hlslpp_inline vector_int4 _hlslpp_cmple_epi32(const vector_int4& x, const vector_int4& y) { return vector_int4(0, 0, 0, 0); }
+	hlslpp_inline vector_int4 _hlslpp_cmpgt_epi32(const vector_int4& x, const vector_int4& y)
+	{
+		return vector_int4(x.x > y.x ? 1 : 0,
+                            x.y > y.y ? 1 : 0, 
+                            x.z > y.z ? 1 : 0, 
+                            x.w > y.w ? 1 : 0);
+	}
+
+	hlslpp_inline vector_int4 _hlslpp_cmpge_epi32(const vector_int4& x, const vector_int4& y)
+	{
+		return vector_int4(x.x >= y.x ? 1 : 0,
+                            x.y >= y.y ? 1 : 0, 
+                            x.z >= y.z ? 1 : 0, 
+                            x.w >= y.w ? 1 : 0);
+	}
+
+	hlslpp_inline vector_int4 _hlslpp_cmplt_epi32(const vector_int4& x, const vector_int4& y)
+	{
+		return vector_int4(x.x < y.x ? 1 : 0,
+                           x.y < y.y ? 1 : 0, 
+                           x.z < y.z ? 1 : 0, 
+                           x.w < y.w ? 1 : 0);
+	}
+
+	hlslpp_inline vector_int4 _hlslpp_cmple_epi32(const vector_int4& x, const vector_int4& y)
+	{
+		return vector_int4(x.x <= y.x ? 1 : 0,
+                           x.y <= y.y ? 1 : 0, 
+                           x.z <= y.z ? 1 : 0, 
+                           x.w <= y.w ? 1 : 0);
+	}
 
 	hlslpp_inline vector_int4 _hlslpp_max_epi32(const vector_int4& v1, const vector_int4& v2)
 	{
@@ -635,32 +674,50 @@ namespace hlslpp
 
 	hlslpp_inline vector_uint4 _hlslpp_cmpeq_epu32(const vector_uint4& x, const vector_uint4& y)
 	{
-		return vector_uint4(0, 0, 0, 0);
+		return vector_uint4(x.x == y.x ? 1 : 0, 
+                            x.y == y.y ? 1 : 0, 
+                            x.z == y.z ? 1 : 0, 
+                            x.w == y.w ? 1 : 0);
 	}
 
 	hlslpp_inline vector_uint4 _hlslpp_cmpneq_epu32(const vector_uint4& x, const vector_uint4& y)
 	{
-		return vector_uint4(0, 0, 0, 0);
+		return vector_uint4(x.x != y.x ? 1 : 0, 
+                            x.y != y.y ? 1 : 0, 
+                            x.z != y.z ? 1 : 0, 
+                            x.w != y.w ? 1 : 0);
 	}
 
 	hlslpp_inline vector_uint4 _hlslpp_cmpgt_epu32(const vector_uint4& x, const vector_uint4& y)
 	{
-		return vector_uint4(0, 0, 0, 0);
+		return vector_uint4(x.x > y.x ? 1 : 0, 
+                            x.y > y.y ? 1 : 0, 
+                            x.z > y.z ? 1 : 0, 
+                            x.w > y.w ? 1 : 0);
 	}
 
 	hlslpp_inline vector_uint4 _hlslpp_cmpge_epu32(const vector_uint4& x, const vector_uint4& y)
 	{
-		return vector_uint4(0, 0, 0, 0);
+		return vector_uint4(x.x >= y.x ? 1 : 0, 
+                            x.y >= y.y ? 1 : 0, 
+                            x.z >= y.z ? 1 : 0, 
+                            x.w >= y.w ? 1 : 0);
 	}
 
 	hlslpp_inline vector_uint4 _hlslpp_cmplt_epu32(const vector_uint4& x, const vector_uint4& y)
 	{
-		return vector_uint4(0, 0, 0, 0);
+		return vector_uint4(x.x < y.x ? 1 : 0, 
+                            x.y < y.y ? 1 : 0, 
+                            x.z < y.z ? 1 : 0, 
+                            x.w < y.w ? 1 : 0);
 	}
 
 	hlslpp_inline vector_uint4 _hlslpp_cmple_epu32(const vector_uint4& x, const vector_uint4& y)
 	{
-		return vector_uint4(0, 0, 0, 0);
+		return vector_uint4(x.x <= y.x ? 1 : 0, 
+                            x.y <= y.y ? 1 : 0, 
+                            x.z <= y.z ? 1 : 0, 
+                            x.w <= y.w ? 1 : 0);
 	}
 
 	hlslpp_inline vector_uint4 _hlslpp_max_epu32(const vector_uint4& v1, const vector_uint4& v2)

--- a/include/platforms/hlsl++_sse.h
+++ b/include/platforms/hlsl++_sse.h
@@ -858,7 +858,7 @@ hlslpp_inline n256i _hlslpp256_or_si128(n256i x, n256i y)
 //-----------------
 
 #define _hlslpp_set1_epu32(x)					_hlslpp_set1_epi32((x))
-#define _hlslpp_set_epu32(x, y, z, w)			_hlslpp_set_epi32((w), (z), (y), (x))
+#define _hlslpp_set_epu32(x, y, z, w)			_hlslpp_set_epi32((x), (y), (z), (w))
 #define _hlslpp_setzero_epu32()					_hlslpp_setzero_epi32()
 
 #define _hlslpp_add_epu32(x, y)					_hlslpp_add_epi32((x), (y))
@@ -874,6 +874,9 @@ hlslpp_inline n256i _hlslpp256_or_si128(n256i x, n256i y)
 
 #define _hlslpp_cmpeq_epu32(x, y)				_hlslpp_cmpeq_epi32((x), (y))
 #define _hlslpp_cmpneq_epu32(x, y)				_hlslpp_cmpneq_epi32((x), (y))
+
+#define _hlslpp_cmpeq1_epu32(x, y)              _hlslpp_cmpeq1_epi32((x), (y))
+#define _hlslpp_cmpneq1_epu32(x, y)             _hlslpp_cmpneq1_epi32((x), (y))
 
 hlslpp_inline n128u _hlslpp_cmpgt_epu32(n128u x, n128u y)
 {


### PR DESCRIPTION
Fix uint4 vector initialized to (w,z,y,x) instead of (x,y,z,w)
Implement operator != and == for uint1, uint2, uint3, uint4
Implement scalar version of several comparison functions for int4 and uint4