### PR TITLE
implement HLSL 'asfloat',  'asuint' and 'asint'

### DIFF
--- a/include/hlsl++_dependent.h
+++ b/include/hlsl++_dependent.h
@@ -48,4 +48,37 @@ namespace hlslpp
 
 #endif
 	}
+
+    //----------------
+// asfloat, asuint, asint
+//----------------
+    hlslpp_inline float1 asfloat(const uint1 & v) { return (float1&)v; }
+    hlslpp_inline float2 asfloat(const uint2 & v) { return (float2&)v; }
+    hlslpp_inline float3 asfloat(const uint3 & v) { return (float3&)v; }
+    hlslpp_inline float4 asfloat(const uint4 & v) { return (float4&)v; }
+
+    hlslpp_inline float1 asfloat(const int1 & v) { return (float1&)v; }
+    hlslpp_inline float2 asfloat(const int2 & v) { return (float2&)v; }
+    hlslpp_inline float3 asfloat(const int3 & v) { return (float3&)v; }
+    hlslpp_inline float4 asfloat(const int4 & v) { return (float4&)v; }
+
+    hlslpp_inline uint1 asuint(const int1 & v) { return (uint1&)v; }
+    hlslpp_inline uint2 asuint(const int2 & v) { return (uint2&)v; }
+    hlslpp_inline uint3 asuint(const int3 & v) { return (uint3&)v; }
+    hlslpp_inline uint4 asuint(const int4 & v) { return (uint4&)v; }
+
+    hlslpp_inline uint1 asuint(const float1 & v) { return (uint1&)v; }
+    hlslpp_inline uint2 asuint(const float2 & v) { return (uint2&)v; }
+    hlslpp_inline uint3 asuint(const float3 & v) { return (uint3&)v; }
+    hlslpp_inline uint4 asuint(const float4 & v) { return (uint4&)v; }
+
+    hlslpp_inline int1 asint(const uint1 & v) { return (int1&)v; }
+    hlslpp_inline int2 asint(const uint2 & v) { return (int2&)v; }
+    hlslpp_inline int3 asint(const uint3 & v) { return (int3&)v; }
+    hlslpp_inline int4 asint(const uint4 & v) { return (int4&)v; }
+
+    hlslpp_inline int1 asint(const float1 & v) { return (int1&)v; }
+    hlslpp_inline int2 asint(const float2 & v) { return (int2&)v; }
+    hlslpp_inline int3 asint(const float3 & v) { return (int3&)v; }
+    hlslpp_inline int4 asint(const float4 & v) { return (int4&)v; }
 }

--- a/include/hlsl++_vector_uint.h
+++ b/include/hlsl++_vector_uint.h
@@ -755,4 +755,39 @@ namespace hlslpp
 		vec = swizzle<0, 1, 2, 3, X, Y, Z, W>(i.vec);
 		return *this;
 	}
+
+    //----------------
+    // asfloat, asuint, asint
+    //----------------
+    hlslpp_inline float1 asfloat(uint1 v) { return (float1&)v; }
+    hlslpp_inline float2 asfloat(uint2 v) { return (float2&)v; }
+    hlslpp_inline float3 asfloat(uint3 v) { return (float3&)v; }
+    hlslpp_inline float4 asfloat(uint4 v) { return (float4&)v; }
+
+    hlslpp_inline float1 asfloat(int1 v) { return (float1&)v; }
+    hlslpp_inline float2 asfloat(int2 v) { return (float2&)v; }
+    hlslpp_inline float3 asfloat(int3 v) { return (float3&)v; }
+    hlslpp_inline float4 asfloat(int4 v) { return (float4&)v; }
+
+    hlslpp_inline uint1 asuint(int1 v) { return (uint1&)v; }
+    hlslpp_inline uint2 asuint(int2 v) { return (uint2&)v; }
+    hlslpp_inline uint3 asuint(int3 v) { return (uint3&)v; }
+    hlslpp_inline uint4 asuint(int4 v) { return (uint4&)v; }
+
+    hlslpp_inline uint1 asuint(float1 v) { return (uint1&)v; }
+    hlslpp_inline uint2 asuint(float2 v) { return (uint2&)v; }
+    hlslpp_inline uint3 asuint(float3 v) { return (uint3&)v; }
+    hlslpp_inline uint4 asuint(float4 v) { return (uint4&)v; }
+
+    hlslpp_inline int1 asint(uint1 v) { return (int1&)v; }
+    hlslpp_inline int2 asint(uint2 v) { return (int2&)v; }
+    hlslpp_inline int3 asint(uint3 v) { return (int3&)v; }
+    hlslpp_inline int4 asint(uint4 v) { return (int4&)v; }
+
+    hlslpp_inline int1 asint(float1 v) { return (int1&)v; }
+    hlslpp_inline int2 asint(float2 v) { return (int2&)v; }
+    hlslpp_inline int3 asint(float3 v) { return (int3&)v; }
+    hlslpp_inline int4 asint(float4 v) { return (int4&)v; }
+
+
 }

--- a/include/hlsl++_vector_uint.h
+++ b/include/hlsl++_vector_uint.h
@@ -755,39 +755,4 @@ namespace hlslpp
 		vec = swizzle<0, 1, 2, 3, X, Y, Z, W>(i.vec);
 		return *this;
 	}
-
-    //----------------
-    // asfloat, asuint, asint
-    //----------------
-    hlslpp_inline float1 asfloat(uint1 v) { return (float1&)v; }
-    hlslpp_inline float2 asfloat(uint2 v) { return (float2&)v; }
-    hlslpp_inline float3 asfloat(uint3 v) { return (float3&)v; }
-    hlslpp_inline float4 asfloat(uint4 v) { return (float4&)v; }
-
-    hlslpp_inline float1 asfloat(int1 v) { return (float1&)v; }
-    hlslpp_inline float2 asfloat(int2 v) { return (float2&)v; }
-    hlslpp_inline float3 asfloat(int3 v) { return (float3&)v; }
-    hlslpp_inline float4 asfloat(int4 v) { return (float4&)v; }
-
-    hlslpp_inline uint1 asuint(int1 v) { return (uint1&)v; }
-    hlslpp_inline uint2 asuint(int2 v) { return (uint2&)v; }
-    hlslpp_inline uint3 asuint(int3 v) { return (uint3&)v; }
-    hlslpp_inline uint4 asuint(int4 v) { return (uint4&)v; }
-
-    hlslpp_inline uint1 asuint(float1 v) { return (uint1&)v; }
-    hlslpp_inline uint2 asuint(float2 v) { return (uint2&)v; }
-    hlslpp_inline uint3 asuint(float3 v) { return (uint3&)v; }
-    hlslpp_inline uint4 asuint(float4 v) { return (uint4&)v; }
-
-    hlslpp_inline int1 asint(uint1 v) { return (int1&)v; }
-    hlslpp_inline int2 asint(uint2 v) { return (int2&)v; }
-    hlslpp_inline int3 asint(uint3 v) { return (int3&)v; }
-    hlslpp_inline int4 asint(uint4 v) { return (int4&)v; }
-
-    hlslpp_inline int1 asint(float1 v) { return (int1&)v; }
-    hlslpp_inline int2 asint(float2 v) { return (int2&)v; }
-    hlslpp_inline int3 asint(float3 v) { return (int3&)v; }
-    hlslpp_inline int4 asint(float4 v) { return (int4&)v; }
-
-
 }

--- a/src/hlsl++_unit_tests.cpp
+++ b/src/hlsl++_unit_tests.cpp
@@ -147,6 +147,32 @@ namespace hlslpp_unit
 		eq(v.w, w);
 	}
 
+    void eq(uint32_t a, uint32_t b)
+    {
+        assert(a == b);
+    }
+
+    void eq(const uint2& v, uint32_t x, uint32_t y)
+    {
+        eq(v.x, x);
+        eq(v.y, y);
+    }
+
+    void eq(const uint3& v, uint32_t x, uint32_t y, uint32_t z)
+    {
+        eq(v.x, x);
+        eq(v.y, y);
+        eq(v.z, z);
+    }
+
+    void eq(const uint4& v, uint32_t x, uint32_t y, uint32_t z, uint32_t w)
+    {
+        eq(v.x, x);
+        eq(v.y, y);
+        eq(v.z, z);
+        eq(v.w, w);
+    }
+
 	void eq(bool a, bool c)
 	{
 		bool equals = a == c;

--- a/src/hlsl++_unit_tests.h
+++ b/src/hlsl++_unit_tests.h
@@ -220,6 +220,14 @@ namespace hlslpp_unit
 
 	void eq(const int4& v, int32_t x, int32_t y, int32_t z, int32_t w);
 
+    void eq(uint32_t a, uint32_t b);
+
+    void eq(const uint2& v, uint32_t x, uint32_t y);
+
+    void eq(const uint3& v, uint32_t x, uint32_t y, uint32_t z);
+
+    void eq(const uint4& v, uint32_t x, uint32_t y, uint32_t z, uint32_t w);
+
 	int32_t shift_left(int32_t a, int32_t b);
 
 	int32_t shift_right(int32_t a, int32_t b);

--- a/src/hlsl++_unit_tests_vector_int.cpp
+++ b/src/hlsl++_unit_tests_vector_int.cpp
@@ -294,6 +294,18 @@ void RunUnitTestsVectorInt()
 	float3 fcastbari_3 = ivfoo3;
 	float4 fcastbari_4 = ivfoo4;
 
+    // reinterpret cast
+    float fval[4] = { 1.0f, 2.0f, 3.0f, 4.0f };
+
+    uint1 uiasfloat_1(*(uint1*)&fval[0]);
+    float1 fasfloat_1 = asfloat(uiasfloat_1); eq(fasfloat_1, fval[0]);
+
+    int2 iasfloat_2(*(int1*)&fval[0], *(int1*)&fval[1]);
+    float2 fasfloat_2 = asfloat(iasfloat_2); eq(fasfloat_2, fval[0], fval[1]);
+
+    uint4 uiasfloat_4 = uint4(*(uint1*)&fval[0], *(uint1*)&fval[1], *(uint1*)&fval[2], *(uint1*)&fval[3]);
+    float4 fasfloat_4 = asfloat(uiasfloat_4); eq(fasfloat_4, fval[0], fval[1], fval[2], fval[3]);
+
 	// Bit shifting
 
 	int1 ivshift_value_1 = int1(1);

--- a/src/hlsl++_unit_tests_vector_int.cpp
+++ b/src/hlsl++_unit_tests_vector_int.cpp
@@ -297,14 +297,57 @@ void RunUnitTestsVectorInt()
     // reinterpret cast
     float fval[4] = { 1.0f, 2.0f, 3.0f, 4.0f };
 
-    uint1 uiasfloat_1(*(uint1*)&fval[0]);
-    float1 fasfloat_1 = asfloat(uiasfloat_1); eq(fasfloat_1, fval[0]);
+    uint1 uiasfloat_1(*(uint32_t*)&fval[0]);
+    float1 fuiasfloat_1 = asfloat(uiasfloat_1); eq(fuiasfloat_1, fval[0]);
 
-    int2 iasfloat_2(*(int1*)&fval[0], *(int1*)&fval[1]);
-    float2 fasfloat_2 = asfloat(iasfloat_2); eq(fasfloat_2, fval[0], fval[1]);
+    uint2 uiasfloat_2 = uint2(*(uint32_t*)&fval[0], *(uint32_t*)&fval[1]);
+    float2 fuiasfloat_2 = asfloat(uiasfloat_2); eq(fuiasfloat_2, fval[0], fval[1]);
 
-    uint4 uiasfloat_4 = uint4(*(uint1*)&fval[0], *(uint1*)&fval[1], *(uint1*)&fval[2], *(uint1*)&fval[3]);
-    float4 fasfloat_4 = asfloat(uiasfloat_4); eq(fasfloat_4, fval[0], fval[1], fval[2], fval[3]);
+    uint3 uiasfloat_3 = uint3(*(uint32_t*)&fval[0], *(uint32_t*)&fval[1], *(uint32_t*)&fval[2]);
+    float3 fuiasfloat_3 = asfloat(uiasfloat_3); eq(fuiasfloat_3, fval[0], fval[1], fval[2]);
+
+    uint4 uiasfloat_4 = uint4(*(uint32_t*)&fval[0], *(uint32_t*)&fval[1], *(uint32_t*)&fval[2], *(uint32_t*)&fval[3]);
+    float4 fuiasfloat_4 = asfloat(uiasfloat_4); eq(fuiasfloat_4, fval[0], fval[1], fval[2], fval[3]);
+
+    int1 iasfloat_1(*(int32_t*)&fval[0]);
+    float1 fiasfloat_1 = asfloat(iasfloat_1); eq(fiasfloat_1, fval[0]);
+
+    int2 iasfloat_2(*(int32_t*)&fval[0], *(int32_t*)&fval[1]);
+    float2 fiasfloat_2 = asfloat(iasfloat_2); eq(fiasfloat_2, fval[0], fval[1]);
+
+    int3 iasfloat_3(*(int32_t*)&fval[0], *(int32_t*)&fval[1], *(int32_t*)&fval[2]);
+    float3 fiasfloat_3 = asfloat(iasfloat_3); eq(fiasfloat_3, fval[0], fval[1], fval[2]);
+
+    int4 iasfloat_4(*(int32_t*)&fval[0], *(int32_t*)&fval[1], *(int32_t*)&fval[2], *(int32_t*)&fval[3]);
+    float4 fiasfloat_4 = asfloat(iasfloat_4); eq(fiasfloat_4, fval[0], fval[1], fval[2], fval[3]);
+
+    uint32_t uival[4] = { 7, 8, 9, 10 };
+
+    float1 fasuint_1(*(float*)&uival[0]);
+    uint1 uisuint_1 = asuint(fasuint_1); eq(uisuint_1, uival[0]);
+
+    float2 fasuint_2(*(float*)&uival[0], *(float*)&uival[1]);
+    uint2 uisuint_2 = asuint(fasuint_2); eq(uisuint_2, uival[0], uival[1]);
+
+    float3 fasuint_3(*(float*)&uival[0], *(float*)&uival[1], *(float*)&uival[2]);
+    uint3 uisuint_3 = asuint(fasuint_3); eq(uisuint_3, uival[0], uival[1], uival[2]);
+
+    float4 fasuint_4(*(float*)&uival[0], *(float*)&uival[1], *(float*)&uival[2], *(float*)&uival[3]);
+    uint4 uisuint_4 = asuint(fasuint_4); eq(uisuint_4, uival[0], uival[1], uival[2], uival[3]);
+
+    int32_t ival[4] = { 11, 12, 13, 14 };
+
+    float1 fasint_1(*(float*)&ival[0]);
+    int1 isuint_1 = asint(fasint_1); eq(isuint_1, ival[0]);
+
+    float2 fasint_2(*(float*)&ival[0], *(float*)&ival[1]);
+    int2 isuint_2 = asint(fasint_2); eq(isuint_2, ival[0], ival[1]);
+
+    float3 fasint_3(*(float*)&ival[0], *(float*)&ival[1], *(float*)&ival[2]);
+    int3 isuint_3 = asint(fasint_3); eq(isuint_3, ival[0], ival[1], ival[2]);
+
+    float4 fasint_4(*(float*)&ival[0], *(float*)&ival[1], *(float*)&ival[2], *(float*)&ival[3]);
+    int4 isuint_4 = asint(fasint_4); eq(isuint_4, ival[0], ival[1], ival[2], ival[3]);
 
 	// Bit shifting
 


### PR DESCRIPTION
'asfloat(x)" interprets the bit pattern of x as a floating-point number.
'asuint(x)" interprets the bit pattern of x as an unsigned integer number.
'asint(x)" interprets the bit pattern of x as a signed integer number.

Can be useful when using uint root/push constants and sharing code between CPU & shaders :)