### PR TITLE
vcpkg cmake support

### DIFF
--- a/hlslpp-config.cmake
+++ b/hlslpp-config.cmake
@@ -1,0 +1,3 @@
+set(hlslpp_VERSION "@VERSION@")
+
+set(hlslpp_INCLUDE_DIRS "${CMAKE_CURRENT_LIST_DIR}/../../include/hlslpp")


### PR DESCRIPTION
This is a helper cmake to set the correct variables for include directory and version. It's meant to be used by vcpkg and is required in order to make the vcpkg port an official port (see https://learn.microsoft.com/en-us/vcpkg/contributing/maintainer-guide#add-cmake-exports-in-an-unofficial--namespace)

Relevant vcpkg PR comments here: https://github.com/microsoft/vcpkg/pull/40400