### PR TITLE
Implement AVX512 specialization of `_hlslpp{,256}_sign_ps `

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -7,7 +7,7 @@ Small header-only math library for C++ with the same syntax as the hlsl shading 
 
 ## Platforms
 
-- SSE/AVX/AVX2: x86/x64 devices like PC, Intel Mac, PS4/5, Xbox One/Series
+- SSE/AVX/AVX2/AVX512: x86/x64 devices like PC, Intel Mac, PS4/5, Xbox One/Series
 - NEON: ARM devices like Android, Mac M1, iOS, Switch
 - WASM
 
@@ -69,7 +69,7 @@ The only required features are a C++ compiler supporting anonymous unions, and S
 
 ## Features
 
-* SSE/AVX/AVX2, NEON, Xbox360, WebAssembly and scalar versions
+* SSE/AVX/AVX2/AVX512, NEON, Xbox360, WebAssembly and scalar versions
 * float1, float2, float3, float4, float8
 * int1, int2, int3, int4
 * uint1, uint2, uint3, uint4

--- a/hlsl++.lua
+++ b/hlsl++.lua
@@ -6,6 +6,7 @@ Workspace = "workspace/".._ACTION
 -- Compilers
 
 -- Visual Studio Configs
+PlatformMSVC64AVX512	= "MSVC 64 AVX512"
 PlatformMSVC64AVX2		= "MSVC 64 AVX2"
 PlatformMSVC64AVX		= "MSVC 64 AVX"
 PlatformMSVC64SSE41		= "MSVC 64 SSE 4.1"
@@ -109,6 +110,7 @@ workspace("hlsl++")
 	
 		platforms
 		{
+			PlatformMSVC64AVX512,
 			PlatformMSVC64AVX2,
 			PlatformMSVC64AVX,
 			PlatformMSVC64SSE41,
@@ -150,6 +152,11 @@ workspace("hlsl++")
 		end
 		
 		startproject(UnitTestProject)
+
+		filter { "platforms:"..PlatformMSVC64AVX512 }
+			toolset("msc")
+			architecture("x64")
+			buildoptions { "/arch:AVX512" }
 		
 		filter { "platforms:"..PlatformMSVC64AVX2 }
 			toolset("msc")

--- a/include/hlsl++/common.h
+++ b/include/hlsl++/common.h
@@ -248,7 +248,9 @@ namespace hlslpp
 #endif
 
 	// Reference http://www.liranuna.com/sse-intrinsics-optimizations-in-popular-compilers/
+#if !defined(_hlslpp_sign_ps)
 	#define _hlslpp_sign_ps(val)				_hlslpp_and_ps(_hlslpp_or_ps(_hlslpp_and_ps((val), f4_minus1), f4_1), _hlslpp_cmpneq_ps((val), f4_0))
+#endif
 	
 	#define _hlslpp_cmpneq1_ps(val1, val2)		_hlslpp_and_ps(_hlslpp_cmpneq_ps((val1), (val2)), f4_1)
 	#define _hlslpp_cmpeq1_ps(val1, val2)		_hlslpp_and_ps(_hlslpp_cmpeq_ps((val1), (val2)), f4_1)
@@ -286,7 +288,9 @@ namespace hlslpp
 	#define _hlslpp_cmplt1_epu32(val1, val2)	_hlslpp_and_si128(_hlslpp_cmplt_epu32((val1), (val2)), u4_1)
 	#define _hlslpp_cmple1_epu32(val1, val2)	_hlslpp_and_si128(_hlslpp_cmple_epu32((val1), (val2)), u4_1)
 
+#if !defined(_hlslpp256_sign_ps)
 	#define _hlslpp256_sign_ps(val)				_hlslpp256_and_ps(_hlslpp256_or_ps(_hlslpp256_and_ps((val), f8minusOne), f8_1), _hlslpp256_cmpneq_ps((val), f8_0))
+#endif
 
 	#define _hlslpp256_cmpneq1_ps(val1, val2)	_hlslpp256_and_ps(_hlslpp256_cmpneq_ps((val1), (val2)), f8_1)
 	#define _hlslpp256_cmpeq1_ps(val1, val2)	_hlslpp256_and_ps(_hlslpp256_cmpeq_ps((val1), (val2)), f8_1)

--- a/include/hlsl++/platforms/sse.h
+++ b/include/hlsl++/platforms/sse.h
@@ -90,6 +90,11 @@ typedef __m256i n256i;
 // _mm_mul_ps(f4_minus1, x);	// Slower
 #define _hlslpp_neg_ps(x)						_mm_xor_ps((x), f4negativeMask)
 
+// https://wunkolo.github.io/post/2022/10/vfixupimm-signum/
+#if defined(__AVX512F__) && defined(__AVX512VL__)
+#define _hlslpp_sign_ps(x)						_mm_fixupimm_ps((x), (x), _mm_set1_epi32(0xa9a90a00), 0)
+#endif
+
 #if defined(__FMA__)
 
 #define _hlslpp_madd_ps(x, y, z)				_mm_fmadd_ps((x), (y), (z)) // x * y + z
@@ -401,6 +406,11 @@ hlslpp_inline void _hlslpp_load4x4_ps(float* p, n128& x0, n128& x1, n128& x2, n1
 // _mm_sub_ps(f4zero, x);			// Slowest
 // _mm_mul_ps(f4minusOne, x);		// Slower
 #define _hlslpp256_neg_ps(x)						_mm256_xor_ps((x), f8negativeMask)
+
+// https://wunkolo.github.io/post/2022/10/vfixupimm-signum/
+#if defined(__AVX512F__) && defined(__AVX512VL__)
+#define _hlslpp256_sign_ps(x)						_mm256_fixupimm_ps((x), (x), _mm256_set1_epi32(0xa9a90a00), 0)
+#endif
 
 #if defined(__FMA__)
 

--- a/src/hlsl++_unit_tests.cpp
+++ b/src/hlsl++_unit_tests.cpp
@@ -482,6 +482,13 @@ namespace hlslpp_unit
 		return (float)((int)x);
 	}
 
+	float sign_f(float x)
+	{
+		if (x > 0.0) return 1.0;
+		if (x < 0.0) return -1.0;
+		return x;
+	}
+
 	double round_d(double x)
 	{
 		double t = trunc_d(x);

--- a/src/hlsl++_unit_tests.h
+++ b/src/hlsl++_unit_tests.h
@@ -349,6 +349,8 @@ namespace hlslpp_unit
 
 	float trunc_f(float x);
 
+	float sign_f(float x);
+
 	double round_d(double x);
 
 	double trunc_d(double x);

--- a/src/hlsl++_unit_tests_vector_float.cpp
+++ b/src/hlsl++_unit_tests_vector_float.cpp
@@ -902,15 +902,15 @@ void RunUnitTestsVectorFloat()
 	float3 vsaturate_swiz_3 = saturate(vfoo3.ggr);  hlslpp_unit_unused(vsaturate_swiz_3);
 	float4 vsaturate_swiz_4 = saturate(vfoo4.wyyx); hlslpp_unit_unused(vsaturate_swiz_4);
 
-	float1 vsign1 = sign(vfoo1); hlslpp_unit_unused(vsign1);
-	float2 vsign2 = sign(vfoo2); hlslpp_unit_unused(vsign2);
-	float3 vsign3 = sign(vfoo3); hlslpp_unit_unused(vsign3);
-	float4 vsign4 = sign(vfoo4); hlslpp_unit_unused(vsign4);
+	float1 vsign1 = sign(vfoo1); hlslpp_check(eq(vsign1, sign_f(vfoo1.x)));
+	float2 vsign2 = sign(vfoo2); hlslpp_check(eq(vsign2, sign_f(vfoo2.x), sign_f(vfoo2.y)));
+	float3 vsign3 = sign(vfoo3); hlslpp_check(eq(vsign3, sign_f(vfoo3.x), sign_f(vfoo3.y), sign_f(vfoo3.z)));
+	float4 vsign4 = sign(vfoo4); hlslpp_check(eq(vsign4, sign_f(vfoo4.x), sign_f(vfoo4.y), sign_f(vfoo4.z), sign_f(vfoo4.w)));
 
-	float1 vsign_swiz_1 = sign(vfoo1.x);    hlslpp_unit_unused(vsign_swiz_1);
-	float2 vsign_swiz_2 = sign(vfoo2.gg);   hlslpp_unit_unused(vsign_swiz_2);
-	float3 vsign_swiz_3 = sign(vfoo3.bbb);  hlslpp_unit_unused(vsign_swiz_3);
-	float4 vsign_swiz_4 = sign(vfoo4.xxyz); hlslpp_unit_unused(vsign_swiz_4);
+	float1 vsign_swiz_1 = sign(vfoo1.x);    hlslpp_check(eq(vsign_swiz_1, sign_f(vfoo1.x)));
+	float2 vsign_swiz_2 = sign(vfoo2.gg);   hlslpp_check(eq(vsign_swiz_2, sign_f(vfoo2.g), sign_f(vfoo2.g)));
+	float3 vsign_swiz_3 = sign(vfoo3.bbb);  hlslpp_check(eq(vsign_swiz_3, sign_f(vfoo3.b), sign_f(vfoo3.b), sign_f(vfoo3.b)));
+	float4 vsign_swiz_4 = sign(vfoo4.xxyz); hlslpp_check(eq(vsign_swiz_4, sign_f(vfoo4.x), sign_f(vfoo4.x), sign_f(vfoo4.y), sign_f(vfoo4.z)));
 
 	float1 vsin1 = sin(vfoo1); hlslpp_unit_unused(vsin1);
 	float2 vsin2 = sin(vfoo2); hlslpp_unit_unused(vsin2);
@@ -1211,7 +1211,7 @@ void RunUnitTestsVectorFloat()
 
 	float8 vsaturate8 = saturate(vfoo8); hlslpp_unit_unused(vsaturate8);
 
-	float8 vsign8 = sign(vfoo8); hlslpp_unit_unused(vsign8);
+	float8 vsign8 = sign(vfoo8); hlslpp_check(eq(vsign8, sign_f(vfoo8[0]), sign_f(vfoo8[1]), sign_f(vfoo8[2]), sign_f(vfoo8[3]), sign_f(vfoo8[4]), sign_f(vfoo8[5]), sign_f(vfoo8[6]), sign_f(vfoo8[7])));
 
 	float8 vsin8 = sin(vfoo8); hlslpp_unit_unused(vsin8);
 


### PR DESCRIPTION
* Adds an MSVC 64 AVX512 build-configuration
* Adds a unit test for single-precision floating-point `sign`
* Implements a fast `sign` function using [vfixupimm](https://wunkolo.github.io/post/2022/10/vfixupimm-signum/) in the case of `AVX512F+AVX512VL` being available.

Ran the benchmarks on my `i9-11900K`:

Before(AVX2):
`sign: Cycles:   5.020442 Elapsed: 0.143277`

After(AVX512):
`sign: Cycles:   2.817079 Elapsed: 0.080396`
